### PR TITLE
feature(lua-support): convert with curly brackets

### DIFF
--- a/lib/ascii-unicode-escape.coffee
+++ b/lib/ascii-unicode-escape.coffee
@@ -14,15 +14,17 @@ module.exports =
 
   convert: ->
     if editor = atom.workspace.getActiveTextEditor()
+       scopes = editor.getRootScopeDescriptor().scopes
        selection = editor.getSelectedText()
        selection = selection.replace /[\s\S]/g, (escape) ->
            code = escape.charCodeAt()
            return escape if code < 128
+           return '\\u{' + ('0000' + code.toString(16)).slice(-4) + '}' if "source.tts.lua" in scopes
            return '\\u' + ('0000' + code.toString(16)).slice(-4)
        editor.insertText("#{selection}")
   reverse: ->
     if editor = atom.workspace.getActiveTextEditor()
-        regex_reverse = /\\u([\d\w]{4})/gi
+        regex_reverse = /\\u{*([\d\w]{4})}*/gi
         selection = editor.getSelectedText()
         selection = selection.replace regex_reverse, (escape, grp) ->
             number = parseInt(grp, 16)


### PR DESCRIPTION
Changes:
  - Escape special characters with curly brackets when the current scope
    is source.tts.lua
  - Recognize curly brackets during reverse convert